### PR TITLE
ci: 为构建流程添加缓存并升级 Actions 依赖

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up `pnpm`
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
+
+      # Install Node.js and cache the pnpm store via cache: pnpm.
+      # When dependencies (pnpm-lock.yaml) are unchanged, the cache is hit 
+      # and the whole dependency download is skipped.
+      - name: Setup Node.js with pnpm cache
+        uses: actions/setup-node@v7
         with:
-          run_install: true
+          node-version: 22
+          cache: pnpm
+
+      # Install dependencies from the lockfile 
+      # so CI matches the local environment (near-instant when deps are unchanged).
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Cache VitePress's Vite pre-bundled deps (saves a bit more build time).
+      - name: Cache VitePress build cache
+        uses: actions/cache@v6
+        with:
+          path: .vitepress/cache
+          key: vitepress-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            vitepress-cache-${{ runner.os }}-
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
- Cache the `pnpm` store via `actions/setup-node`'s cache: pnpm, skipping the full dependency download when deps are unchanged
- Cache VitePress's Vite pre-bundled deps with `actions/cache to trim build time further
- Switch to `pnpm install --frozen-lockfile` to keep CI consistent with the local lockfile
- Upgrade to `actions/checkout@v7`, `pnpm/action-setup@v6`, `actions/setup-node@v7`, `actions/cache@v6`

---

- 使用 `actions/setup-node` 的 cache: `pnpm` 缓存 pnpm store，依赖未变时直接跳过
- 通过 `actions/cache` 缓存 VitePress 的预构建产物
- 改用 `pnpm install --frozen-lockfile` 保证 CI 与本地锁文件一致
- 升级 CI/CD 依赖至 `actions/checkout@v7`、`pnpm/action-setup@v6`、`actions/setup-node@v7`、`actions/cache@v6`
