### PR TITLE
ci: 移除无效的 VitePress 缓存

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,28 +16,16 @@ jobs:
       - name: Set up `pnpm`
         uses: pnpm/action-setup@v6
 
-      # Install Node.js and cache the pnpm store via cache: pnpm.
-      # When dependencies (pnpm-lock.yaml) are unchanged, the cache is hit 
-      # and the whole dependency download is skipped.
+      # Install Node.js and cache pnpm's package store.
       - name: Setup Node.js with pnpm cache
         uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
 
-      # Install dependencies from the lockfile 
-      # so CI matches the local environment (near-instant when deps are unchanged).
-      - name: Install dependencies
+      # CI only builds the root VitePress site, so child projects are not installed.
+      - name: Install root dependencies
         run: pnpm install --frozen-lockfile
-
-      # Cache VitePress's Vite pre-bundled deps (saves a bit more build time).
-      - name: Cache VitePress build cache
-        uses: actions/cache@v6
-        with:
-          path: .vitepress/cache
-          key: vitepress-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            vitepress-cache-${{ runner.os }}-
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
## 修改内容

- 删除不会被 `vitepress build` 生成的 `.vitepress/cache` 缓存步骤
- 保留正常工作的 pnpm store 缓存
- 明确 CI 仅安装根目录依赖，因为当前只构建根 VitePress 站点
- 修正缓存注释，避免暗示命中缓存后无需执行依赖安装

## 原因

合并 #122 后的 CI 日志在 post step 中提示：

```text
Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

因此该缓存步骤不会保存或恢复任何内容，只会在每次运行结束时产生警告。